### PR TITLE
add compares-to-latest function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ steps:
     id: chipmunk_version
 ```
 
+Compare with the current github ref:
+
+```yaml
+steps:
+  - uses: oprypin/find-latest-tag@v1
+    id: upstream-latest
+    with:
+      repository: cloudflare/wrangler
+      compare-to: ${{ github.ref }}
+  - run: |
+      echo "Upstream latest tag is equal (than this github.ref): ${{ steps.upstream-latest.outputs.equal }}"
+      echo "Upstream latest tag is newer (than this github.ref): ${{ steps.upstream-latest.outputs.equal }}"
+      echo "Upstream latest tag is older (than this github.ref): ${{ steps.upstream-latest.outputs.equal }}"
+```
+
 [Find usages in the wild!](https://github.com/search?l=YAML&q=%22oprypin%2Ffind-latest-tag%22&type=Code)
 
 ## Usage
@@ -66,6 +81,10 @@ steps:
 
   Return the first tag reported by GitHub. It's safe to rely on this being the **most recently created** release only for `releases-only: false`. When looking at tags, the behavior is undefined.
 
+* **`compare-to: 'v1.2.3'`** (default for `compare-to: ''`)
+
+  Compare the repository latest tag with the version provied (ex. v1.2.3). Note that ${{ github.ref }} is also supported. If the latest tag in the given repository found then it is compared to the `compare-to` value. Result is stored into `newer`/`older`/`equal` can be `true`, `false` or *the output can be omitted*.
+
 * **`token: ${{ secrets.PERSONAL_TOKEN }}`**
 
   Required for scanning tags of **other private repositories** (referred to as *destination* repo), because the default `GITHUB_TOKEN` only gives access to the repository that's *running* the action (and public ones).
@@ -79,6 +98,18 @@ steps:
 * **`tag`** (`${{ steps.some_step_id.outputs.tag }}`)
 
   The tag that was found is made available as the step's output.
+
+* **`newer`** (`${{ steps.some_step_id.outputs.newer }}`)
+
+  If the latest tag found (in the given repository) is newer than specifed `compare-to` value then result is `true` otherwise `false`. Output can be omitted which indicates that the latest tag hasn't been found due to absence or filtered out be means of `regex`, `prefix` or other parameters.
+
+* **`older`** (`${{ steps.some_step_id.outputs.older }}`)
+
+  Similar to the `newer` output.
+
+* **`equal`** (`${{ steps.some_step_id.outputs.equal }}`)
+
+  Similar to the `newer` output.
 
 ### Errors
 

--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,21 @@ inputs:
     description: Consider only tags that matches specified RegEx pattern.
   sort-tags:
     description: If true, look through all tags to find the greatest (semver-like) version, else just get the most recent tag. Defaults to true (strongly recommended), or to false if *releases-only* is enabled
+  compare-to:
+    description: Compare the given repository the latest tag to the specified version (can be alaso a tag reference)
   token:
     description: Personal access token (auto-populated). It is used only because anonymous requests are rate-limited. It can be overridden to an empty value.
     default: ${{ github.token }}
 outputs:
   tag:
     description: The full tag name (incl. prefix) that was found
+  equal:
+    description: Indicates that the given repository latest tag is same with compare-to value (true/false/"").
+  newer:
+    description: Indicates that the given repository latest tag is newer with compare-to value (true/false/"").
+  older:
+    description: Indicates that the given repository latest tag is older with compare-to value (true/false/"").
+
 runs:
   using: node12
   main: index.js

--- a/index.js
+++ b/index.js
@@ -15,12 +15,24 @@ async function run() {
         const regex = core.getInput("regex") || null;
 
         const releasesOnly = (core.getInput("releases-only") || "false").toLowerCase() === "true";
+        const compareToValue = core.getInput("compare-to") || "";
 
         // It's somewhat safe to assume that the most recenly created release is actually latest.
         const sortTagsDefault = (releasesOnly ? "false" : "true");
         const sortTags = (core.getInput("sort-tags") || sortTagsDefault).toLowerCase() === "true";
 
-        core.setOutput("tag", await getLatestTag(owner, repo, releasesOnly, prefix, regex, sortTags));
+        let latestTag = await getLatestTag(owner, repo, releasesOnly, prefix, regex, sortTags);
+        core.setOutput("tag", latestTag);
+        core.info(`tag: ${latestTag}`);
+
+        // Get comaresTo object, and set outputs if not empty
+        if (latestTag && compareToValue) {
+            let comp = compareRefOrTag(latestTag, compareToValue, regex);
+            for (let outputName in comp) {
+                core.setOutput(outputName, comp[outputName]);
+                core.info(`${outputName}: ${comp[outputName]}`);
+            }
+        }
     } catch (error) {
         core.setFailed(error);
     }
@@ -47,17 +59,39 @@ async function getLatestTag(owner, repo, releasesOnly, prefix, regex, sortTags) 
         }
         tags.push(tag);
     }
+
+    // Notify that no tags/releases have been found
     if (tags.length === 0) {
-        let error = `The repository "${owner}/${repo}" has no `;
-        error += releasesOnly ? "releases" : "tags";
+        let warn = `The repository "${owner}/${repo}" has no `;
+        warn += releasesOnly ? "releases" : "tags";
         if (prefix) {
-            error += ` matching "${prefix}*"`;
+            warn += ` matching "${prefix}*"`;
         }
-        throw error;
+        core.warning(warn);
+        return "";
     }
+
     tags.sort(cmpTags);
     const [latestTag] = tags.slice(-1);
+
     return latestTag;
+}
+
+function compareRefOrTag(latest, ref, regex = "") {
+    // strip of the refs prefix
+    const tag = ref.replace(/refs\/(heads|tags)\//, "");
+
+    // don't respect value which doesn't match the regex
+    if (regex && !new RegExp(regex).test(tag)) {
+        return {};
+    }
+
+    let cmpres = cmpTags(latest, tag);
+    return {
+        equal: cmpres === 0,
+        newer: cmpres === 1,
+        older: cmpres === -1,
+    };
 }
 
 async function* getItemsFromPages(pages) {


### PR DESCRIPTION
Howdy @oprypin,

I've added a function to compare a given tag/ref value to the found latest tag. This case might actually useful with `docker/metadata-action` for instance:

```yaml
 - uses: dysnix/find-latest-tag@v1
   id: compares
   with:
     repository: name/app
     compares-to-latest: ${{ github.ref }}
  -
    name: Docker meta
    id: meta
    uses: docker/metadata-action@v3
    with:
      images: name/app
      # when the ref tag is newer or coeval to latest, older is false, so we can create docker tag for the latest. 
      flavor: |
        latest=${{ steps.compares.outputs.older == 'false' }}
      tags: |
        type=semver,pattern={{version}}
        type=sha
```

![Selection_006](https://user-images.githubusercontent.com/891419/121698697-ecd31280-cad6-11eb-9ca2-cbf800bd3f04.png)

Thank you for your tag-cmp and action, they are very handy :+1: 