### PR TITLE
Add pre-release condition filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ steps:
 
   Consider all tags.
 
+* **`pre-release: true`**
+
+  Consider only tags that are pre-releases.
+
+* **`pre-release: false`**
+
+  Consider only tags that are not pre-releases.
+
 * **`prefix: 'someprefix-'`**
 
   Consider only tags starting with this string prefix, like "someprefix-1.2.3". The prefix will **not** be excluded from the result.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,8 @@ inputs:
     required: true
   releases-only:
     description: If true, consider only tags that have an associated release
+  pre-release:
+    description: If true, consider only pre-release tags
   prefix:
     description: Consider only tags starting with this string prefix
   regex:


### PR DESCRIPTION
# Description
This PR introduce the `pre-release` arg, this argument is only effected when `releases-only` set to `true`

# Behaviour
+ not set:
    + If user didn't specify the `pre-relase` argument in action, it'll return all releases(no matter it's pre-release or not)
+ `true`
    + Only releases which is pre-release will be returned
+ `false`
    + Only releases which is *not* pre-release will be returned
